### PR TITLE
Fixes and bevy 0.14 support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /target
 Cargo.lock
 .DS_Store
+*.obj

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ tobj = { version = "4", optional = true }
 ultraviolet = { version = "0.9", features = ["f64"] }
 
 [dev-dependencies]
-dirs = "5.0"
 kiss3d = { version = "0.35", features = ["vertex_index_u32"] }
 bytemuck = "1.14.3"
 slice-of-array = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polyhedron-ops"
-version = "0.2.8"
+version = "0.2.9"
 authors = ["Moritz Moeller <virtualritz@gmail.com>"]
 edition = "2021"
 keywords = ["3d", "creative", "geometry", "graphics", "rendering"]
@@ -19,13 +19,18 @@ obj = ["tobj"]
 parser = ["pest", "pest_derive"]
 nsi = ["nsi-core", "bytemuck"]
 bevy = ["dep:bevy", "bevy_panorbit_camera"]
+tilings = []
 
 [dependencies]
 # Add support to convert a Polyhedron into a bevy Mesh.
-bevy = { version = "0.13", default-features = false, features = ["bevy_pbr"], optional = true }
-bevy_panorbit_camera = { version = "0.16", optional = true }
-bytemuck = { version = "1.14", features = ["extern_crate_alloc"], optional = true }
-itertools = "0.12"
+bevy = { version = "0.14", default-features = false, features = [
+    "bevy_pbr",
+], optional = true }
+bevy_panorbit_camera = { version = "0.19", optional = true }
+bytemuck = { version = "1.14", features = [
+    "extern_crate_alloc",
+], optional = true }
+itertools = "0.13"
 # Add support to render polyhedra with NSI.
 nsi-core = { version = "0.8", optional = true }
 num-traits = "0.2"
@@ -37,20 +42,29 @@ ultraviolet = { version = "0.9", features = ["f64"] }
 
 [dev-dependencies]
 dirs = "5.0"
-kiss3d = { version = "0.35", features = [ "vertex_index_u32" ] }
+kiss3d = { version = "0.35", features = ["vertex_index_u32"] }
 bytemuck = "1.14.3"
 slice-of-array = "0.3"
 
 [target.'cfg(target_os = "linux")'.dependencies.bevy]
+version = "*"
 features = ["x11", "wayland"]
 
-[profile.release]
-lto = true
+[profile.dev]
+opt-level = 1
+
+[profile.dev.package."*"]
 opt-level = 3
 codegen-units = 1
 
-[profile.dev]
-opt-level = 3
+[profile.release]
+codegen-units = 1
+lto = "thin"
+
+[profile.wasm-release]
+inherits = "release"
+opt-level = "s"
+strip = "debuginfo"
 
 [[example]]
 name = "playground"

--- a/examples/bevy/main.rs
+++ b/examples/bevy/main.rs
@@ -1,11 +1,12 @@
 use bevy::{
     app::{App, Startup},
     asset::Assets,
+    color::Color,
     core_pipeline::core_3d::Camera3dBundle,
     ecs::system::{Commands, ResMut},
     math::Vec3,
     pbr::{DirectionalLightBundle, PbrBundle, StandardMaterial},
-    render::{color::Color, mesh::Mesh, view::Msaa},
+    render::{mesh::Mesh, view::Msaa},
     transform::components::Transform,
     utils::default,
     DefaultPlugins,
@@ -18,7 +19,7 @@ fn main() {
         .insert_resource(Msaa::Sample4)
         .add_plugins(DefaultPlugins)
         .add_plugins(PanOrbitCameraPlugin)
-        .add_systems(Startup, (setup, bevy::window::close_on_esc))
+        .add_systems(Startup, setup)
         .run();
 }
 
@@ -35,7 +36,7 @@ fn setup(
 
     commands.spawn(PbrBundle {
         mesh: meshes.add(Mesh::from(polyhedron)),
-        material: materials.add(Color::rgb(0.4, 0.35, 0.3)),
+        material: materials.add(Color::srgb(0.4, 0.35, 0.3)),
         ..Default::default()
     });
 

--- a/examples/playground/main.rs
+++ b/examples/playground/main.rs
@@ -10,7 +10,8 @@ use na::{Point3, Vector3};
 use polyhedron_ops::*;
 use rayon::prelude::*;
 use std::{
-    cell::RefCell, env, error::Error, io, io::Write, path::Path, rc::Rc,
+    cell::RefCell, env, env::current_dir, error::Error, io, io::Write,
+    path::Path, rc::Rc,
 };
 
 #[cfg(feature = "nsi")]
@@ -93,7 +94,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut alter_last_op = false;
     let mut last_poly = poly.clone();
 
-    let path = dirs::home_dir().unwrap();
+    let path = current_dir()?;
     let mut render_quality = 0;
 
     let mut turntable = false;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -97,8 +97,8 @@ impl Polyhedron {
         regular_faces_only: Option<bool>,
         change_name: bool,
     ) -> &mut Self {
-        self.truncate(height, face_arity_mask, regular_faces_only, false);
         self.ambo(ratio, false);
+        self.truncate(height, face_arity_mask, regular_faces_only, false);
 
         if change_name {
             let mut params = String::new();
@@ -803,9 +803,9 @@ impl Polyhedron {
         regular_faces_only: Option<bool>,
         change_name: bool,
     ) -> &mut Self {
-        self.dual(false);
-        self.truncate(height, vertex_valence_mask, regular_faces_only, false);
         self.ambo(ratio, false);
+        self.truncate(height, vertex_valence_mask, regular_faces_only, false);
+        self.dual(false);
 
         if change_name {
             let mut params = String::new();
@@ -858,6 +858,7 @@ impl Polyhedron {
         regular_faces_only: Option<bool>,
         change_name: bool,
     ) -> &mut Self {
+        self.join(ratio, false);
         self.kis(
             height,
             match vertex_valence_mask {
@@ -869,7 +870,6 @@ impl Polyhedron {
             regular_faces_only,
             false,
         );
-        self.join(ratio, false);
 
         if change_name {
             let mut params = String::new();
@@ -920,8 +920,8 @@ impl Polyhedron {
         regular_faces_only: Option<bool>,
         change_name: bool,
     ) -> &mut Self {
-        self.dual(false);
         self.truncate(height, vertex_valence_mask, regular_faces_only, false);
+        self.dual(false);
 
         if change_name {
             let mut params = String::new();
@@ -1464,8 +1464,8 @@ impl Polyhedron {
         regular_faces_only: Option<bool>,
         change_name: bool,
     ) -> &mut Self {
-        self.dual(false);
         self.kis(height, face_arity_mask, None, regular_faces_only, false);
+        self.dual(false);
 
         if change_name {
             let mut params = String::new();


### PR DESCRIPTION
Thank you for creating this library, I hope these contributions are welcome.

I made the following changes to support bevy v0.14 builds on Linux, and noticed a few order of operations were reversed when rendering Goldberg polyhedra.