### PR TITLE
Console support for live renders in Bevy example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,16 +20,19 @@ parser = ["pest", "pest_derive"]
 nsi = ["nsi-core", "bytemuck"]
 bevy = ["dep:bevy", "bevy_panorbit_camera"]
 tilings = []
+console = ["bevy", "parser", "bevy_console", "clap"]
 
 [dependencies]
 # Add support to convert a Polyhedron into a bevy Mesh.
 bevy = { version = "0.14", default-features = false, features = [
     "bevy_pbr",
 ], optional = true }
+bevy_console = { version = "0.12", optional = true }
 bevy_panorbit_camera = { version = "0.19", optional = true }
 bytemuck = { version = "1.14", features = [
     "extern_crate_alloc",
 ], optional = true }
+clap = { version = "4.5", optional = true }
 itertools = "0.13"
 # Add support to render polyhedra with NSI.
 nsi-core = { version = "0.8", optional = true }

--- a/examples/bevy/console.rs
+++ b/examples/bevy/console.rs
@@ -1,0 +1,50 @@
+use crate::RootPolyhedron;
+use bevy::prelude::{error, info, Assets, Handle, Mesh, Query, ResMut, With};
+use bevy_console::ConsoleCommand;
+use clap::Parser;
+use polyhedron_ops::Polyhedron;
+use std::{error::Error, mem::replace};
+
+pub mod prelude {
+    pub use crate::console::{render_command, RenderCommand};
+    pub use bevy_console::{AddConsoleCommand, ConsolePlugin};
+}
+
+fn render(conway: String) -> Result<Polyhedron, Box<dyn Error>> {
+    let polyhedron = Polyhedron::try_from(conway.as_str())?
+        .normalize()
+        .finalize();
+    Ok(polyhedron)
+}
+
+#[derive(Parser, ConsoleCommand)]
+#[command(name = "render")]
+pub struct RenderCommand {
+    conway: String,
+}
+
+pub fn render_command(
+    mesh_query: Query<&Handle<Mesh>, With<RootPolyhedron>>,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut log: ConsoleCommand<RenderCommand>,
+) {
+    if let Some(Ok(RenderCommand { conway })) = log.take() {
+        let update = || -> Result<String, Box<dyn Error>> {
+            let polyhedron = render(conway)?;
+            let mesh_handle = mesh_query.get_single()?;
+            let mesh = meshes
+                .get_mut(mesh_handle)
+                .ok_or("Root polyhedron mesh not found")?;
+            let name = polyhedron.name().clone();
+            let _ = replace::<Mesh>(mesh, Mesh::from(polyhedron));
+            Ok(name)
+        };
+
+        match update() {
+            Ok(name) => {
+                info!("Rendered polyhedron: {name}")
+            }
+            Err(e) => error!("Unable to render polyhedron: {e:?}"),
+        }
+    }
+}


### PR DESCRIPTION
I added the following functionality to the bevy example while having some fun rendering shapes.  I hope these changes are welcome, thanks again for this crate!

The bevy console can be opened using the back-quote key (\`).
The render command can be used to update the displayed polyhedron.
Below is a screenshot after running: `render gacpD`

![image](https://github.com/user-attachments/assets/9596fd4a-8e96-4650-8bda-2b908d98176e)

It can be built with the following command:
`cargo build --release --example bevy --features=console`